### PR TITLE
Add support for --paths, --ignoreMissing, and --tsconfig options

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,7 @@ const commander = require('commander');
 const through = require('through2');
 const tmp = bluebird.promisifyAll(require('tmp'));
 const AWS = require('aws-sdk');
+const tsify = require('tsify');
 
 
 tmp.setGracefulCleanup();
@@ -46,16 +47,21 @@ exports.getPackageFiles = getPackageFiles;
  * Given a startFile path, returns a Promise for an array of all dependencies to include in the
  * package, including any necessary package.json files.
  */
-function listDependencies(startFile) {
+function listDependencies(startFile, options = {}) {
   var b = browserify({
       entries: [startFile],
       builtins: false,
       commondir: false,
       browserField: false,
       dedupe: true,
-      ignoreMissing: true,
+      ignoreMissing: options.ignoreMissing,
       debug: false,
+      paths: options.paths,
   });
+
+  if (options.tsconfig) {
+    b.plugin(tsify, { project: options.tsconfig });
+  }
 
   b.exclude('aws-sdk');
 
@@ -99,8 +105,8 @@ exports.spawn = spawn;
  * @param {String} zipFile: The name of the zip file to create. It will be overwritten if exists.
  * @returns {Promise} Promise that resolves on success.
  */
-function packageLambda(startFile, zipFile) {
-  return listDependencies(startFile)
+function packageLambda(startFile, zipFile, options) {
+  return listDependencies(startFile, options)
   .then(paths =>
     fs.unlinkAsync(zipFile).catch(() => {})
     .then(() => spawn('zip', ['-q', zipFile].concat(paths)))
@@ -137,7 +143,7 @@ function uploadLambda(startFile, options) {
   .then(_zipFile => {
     zipFile = _zipFile;
     console.log(`Building '${startFile}' into '${zipFile}'`);
-    return packageLambda(startFile, zipFile);
+    return packageLambda(startFile, zipFile, options);
   })
   .then(() => {
     if (options.output) {
@@ -168,6 +174,10 @@ function main() {
   .option('-l, --lambda <string>', 'Name of lambda. Defaults to basename of start_file')
   .option('-r, --region <string>', 'AWS region to use.')
   .option('-o, --output <path>', 'Just create a zip file with the packaged lambda code')
+  .option('--ignore-missing, --im', "Ignore require() statements that don't resolve to anything")
+  .option('--paths <paths>', 'Colon-delimited list of extra directories to search for modules',
+    val => val.split(':'))
+  .option('--tsconfig <path>', 'If given, process TypeScript using the given tsconfig.json')
   .arguments('<start_file>')
   .action((startFile, options) => uploadLambda(startFile, options.opts()));
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "tmp": "0.0.31"
   },
   "devDependencies": {
-    "mocha": "^3.4.2"
+    "mocha": "^3.4.2",
+    "tsify": "^3.0.3",
+    "typescript": "^2.5.3"
   }
 }

--- a/test/fixtures/abs.js
+++ b/test/fixtures/abs.js
@@ -1,0 +1,3 @@
+require('dep1');
+require('lib/dep.js');
+console.log("Abs");

--- a/test/fixtures/lib/ts2.ts
+++ b/test/fixtures/lib/ts2.ts
@@ -1,0 +1,2 @@
+import * as dep2 from 'dep2';
+console.log("Ts2.ts");

--- a/test/fixtures/ts1.js
+++ b/test/fixtures/ts1.js
@@ -1,0 +1,4 @@
+require('dep1');
+require('lib/ts2');
+require('lib/dep');
+console.log("Ts1");

--- a/test/fixtures/tsconfig.json
+++ b/test/fixtures/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "strict": true,
+    "noImplicitAny": false,
+    "moduleResolution": "node",
+    "baseUrl": "."
+  }
+}

--- a/test/test_main.js
+++ b/test/test_main.js
@@ -26,6 +26,51 @@ describe("listDependencies", function() {
       "test/fixtures/lib/dep.js",
       "test/fixtures/node_modules/dep2/bye.js",
       "test/fixtures/node_modules/dep2/package.json",
+    ]))
+  });
+
+  it("should support ignoreMissing option", function() {
+    // Absolute imports will fail without some help.
+    return main.listDependencies('test/fixtures/abs.js')
+    .then(() => assert(false, 'Expected listDependencies abs.js to fail'),
+      (err) => assert(/Cannot find.*lib\/dep/.test(err.message))
+    )
+
+    // But with ignoreMissing=true, they'll work, and find as much as they find.
+    .then(() => main.listDependencies('test/fixtures/abs.js', {ignoreMissing: true}))
+    .then(paths => assert.deepEqual(paths, [
+      "test/fixtures/abs.js",
+      "test/fixtures/node_modules/dep1/hello.js",
+      "test/fixtures/node_modules/dep1/package.json",
+    ]));
+  });
+
+  it("should support paths option", function() {
+    return main.listDependencies('test/fixtures/abs.js', {paths: ['test/fixtures']})
+    .then(paths => assert.deepEqual(paths, [
+      "test/fixtures/abs.js",
+      "test/fixtures/lib/dep.js",
+      "test/fixtures/node_modules/dep1/hello.js",
+      "test/fixtures/node_modules/dep1/package.json",
+      "test/fixtures/node_modules/dep2/bye.js",
+      "test/fixtures/node_modules/dep2/package.json",
+    ]));
+  });
+
+  it("should find typescript files", function() {
+    this.timeout(5000);
+    return main.listDependencies('test/fixtures/ts1.js', {
+      paths: ['test/fixtures'],
+      tsconfig: 'test/fixtures/tsconfig.json'
+    })
+    .then(paths => assert.deepEqual(paths, [
+      "test/fixtures/lib/dep.js",
+      "test/fixtures/lib/ts2.ts",
+      "test/fixtures/node_modules/dep1/hello.js",
+      "test/fixtures/node_modules/dep1/package.json",
+      "test/fixtures/node_modules/dep2/bye.js",
+      "test/fixtures/node_modules/dep2/package.json",
+      "test/fixtures/ts1.js",
     ]));
   });
 });


### PR DESCRIPTION
This what I have so far. It allows aws-lambda-upload to find .ts files and includes them into the archive, but it doesn't actually translate them.